### PR TITLE
Update .zenodo.json

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -12,8 +12,6 @@
         }
     ],    
   
-    "license": "Creative Commons Attribution 4.0 International",
-
     "title": "Talk: Social coding and open software",
 
     "keywords": ["Programming", "Computer Science"]


### PR DESCRIPTION
Removed the license in zenodo.json.
Zenodo requires precise spelling in the specification of license, otherwise the license is not recognized.